### PR TITLE
Multiple fixes to get everything working on RPi3 with built-in bluetooth

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Nuimo Controller",
-    "version": "1.0.0",
+    "version": "1.0.6",
     "slug": "nuimo",
     "description": "Addon for Nuimo controller by Scenic, implemented with NodeJS and MQTT",
     "startup": "application",
@@ -12,5 +12,8 @@
             "password": ""
         }
     },
-    "schema": {}
+    "host_network": "true",
+    "schema": {},
+    "privileged": ["NET_ADMIN", "SYS_ADMIN", "SYS_RAWIO"],
+    "devices": ["/dev/ttyAMA0:/dev/ttyAMA0:rwm"]
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "debug": ">=2.2.0",
     "mqtt": "2.12.1",
     "noble": ">=1.8.0",
-    "nuimojs": "1.0.3"
+    "nuimojs": "1.0.3",
+    "bluetooth-hci-socket": "^0.5.1"
   }
 }


### PR DESCRIPTION
It's possible that not all the privileges granted here are required, but
I currently have limited time for rebuilding and testing each combination.

Also I bumped the minor version a few times during local testing.

Note that for everything to work, the "Bluetooth BCM43xx" add-on (supplied with Hassio) needs to be installed and started.

Fixes #2.